### PR TITLE
add readSpikeRaw_Phy.m and external functions to import spike data from Phy

### DIFF
--- a/external/npy-matlab-master/.gitignore
+++ b/external/npy-matlab-master/.gitignore
@@ -1,0 +1,3 @@
+*.asv
+.ipynb_checkpoints/
+__pycache__

--- a/external/npy-matlab-master/.travis.yml
+++ b/external/npy-matlab-master/.travis.yml
@@ -1,0 +1,38 @@
+# Using several other .travis.yml files as inspiration. See for example:
+# https://github.com/MOxUnit/MOxUnit
+# https://github.com/scottclowe/matlab-continuous-integration/
+# https://github.com/fieldtrip/fieldtrip/blob/master/.travis.yml
+
+language: python
+
+cache:
+    - apt
+
+before_install:
+    # to prevent IPv6 being used for APT
+    - sudo bash -c "echo 'Acquire::ForceIPv4 \"true\";' > /etc/apt/apt.conf.d/99force-ipv4"
+    - travis_retry sudo apt-get -y -qq update
+    - travis_retry sudo apt-get install -y -qq software-properties-common python-software-properties
+    - travis_retry sudo apt-add-repository -y ppa:octave/stable
+    - travis_retry sudo apt-get -y -qq update
+    # get Octave 4.0
+    - travis_retry sudo apt-get -y -qq install octave liboctave-dev
+
+    # Get conda
+    - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b -p /home/travis/miniconda
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes --quiet conda
+
+install:
+    - conda create -n testenv --yes python=3.6
+    - source activate testenv
+    - conda install --yes --quiet numpy
+    - conda install --yes -c conda-forge scikit-image
+    - pip install pytest==3.3.2 pytest-sugar
+
+script:
+    - echo "Octave version:"
+    - octave --no-gui --eval "version()"
+    - pytest

--- a/external/npy-matlab-master/LICENSE
+++ b/external/npy-matlab-master/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2015, npy-matlab developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/external/npy-matlab-master/README.md
+++ b/external/npy-matlab-master/README.md
@@ -1,0 +1,49 @@
+[![Travis](https://api.travis-ci.org/kwikteam/npy-matlab.svg?branch=master "Travis")](https://travis-ci.org/kwikteam/npy-matlab)
+# npy-matlab
+
+Code to read and write NumPy's NPY format (`.npy` files) in MATLAB.
+
+This is experimental code and still work in progress. For example, this code:
+- Only reads a subset of all possible NPY files, specifically N-D arrays of
+  certain data types.
+- Only writes little endian, fortran (column-major) ordering
+- Only writes with NPY version number 1.0.
+- Always outputs a shape according to matlab's convention, e.g. (10, 1)
+  rather than (10,).
+
+Feel free to open an issue and/or send a pull request for improving the
+state of this project!
+
+For the complete specification of the NPY format, see the [NumPy documentation](https://www.numpy.org/devdocs/reference/generated/numpy.lib.format.html).
+
+## Installation
+After downloading npy-matlab as a zip file or via git, just add the
+npy-matlab directory to your search path:
+
+```matlab
+>> addpath('my-idiosyncratic-path/npy-matlab/npy-matlab')  
+>> savepath
+```
+
+## Usage example
+```matlab
+>> a = rand(5,4,3);
+>> writeNPY(a, 'a.npy');
+>> b = readNPY('a.npy');
+>> sum(a(:)==b(:))
+ans =
+
+    60
+```
+
+## Tests
+Roundtrip testing is performed using Travis CI and GNU Octave, see
+the `.travis.yml` file and `tests/test_npy_roundtrip.py`.
+
+You can also use two "manual testing scripts":
+
+- See `tests/npy.ipynb` for Python tests.
+- See `tests/test_readNPY.m` for MATLAB reading/writing tests.
+
+## Memory mapping npy files
+See `examples/exampleMemmap.m` for an example of how to memory map a `.npy` file in MATLAB, which is not trivial when the file uses C-ordering (i.e., row-major order) rather than Fortran-ordering (i.e., column-major ordering). MATLAB's memory mapping only supports Fortran-ordering, but Python's default is C-ordering so `.npy` files created with Python defaults are not straightforward to read in MATLAB.

--- a/external/npy-matlab-master/examples/exampleMemmap.m
+++ b/external/npy-matlab-master/examples/exampleMemmap.m
@@ -1,0 +1,23 @@
+
+
+% Example implementation of memory mapping an NPY file using readNPYheader
+
+filename = 'data/chelsea_float64.npy';
+
+[arrayShape, dataType, fortranOrder, littleEndian, totalHeaderLength, npyVersion] = readNPYheader(filename);
+
+figure;
+
+if fortranOrder
+    f = memmapfile(filename, 'Format', {dataType, arrayShape, 'd'}, 'Offset', totalHeaderLength);
+    image(f.Data.d)
+    
+else
+    % Note! In this case, the dimensions of the array will be transposed,
+    % e.g. an AxBxCxD array becomes DxCxBxA. 
+    f = memmapfile(filename, 'Format', {dataType, arrayShape(end:-1:1), 'd'}, 'Offset', totalHeaderLength);
+    
+    tmp = f.Data.d;
+    img = permute(tmp, length(arrayShape):-1:1); % note here you have to reverse the dimensions. 
+    image(img./255)
+end

--- a/external/npy-matlab-master/npy-matlab/constructNPYheader.m
+++ b/external/npy-matlab-master/npy-matlab/constructNPYheader.m
@@ -1,0 +1,88 @@
+
+
+
+function header = constructNPYheader(dataType, shape, varargin)
+
+	if ~isempty(varargin)
+		fortranOrder = varargin{1}; % must be true/false
+		littleEndian = varargin{2}; % must be true/false
+	else
+		fortranOrder = true;
+		littleEndian = true;
+	end
+
+    dtypesMatlab = {'uint8','uint16','uint32','uint64','int8','int16','int32','int64','single','double', 'logical'};
+    dtypesNPY = {'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8', 'f4', 'f8', 'b1'};
+
+    magicString = uint8([147 78 85 77 80 89]); %x93NUMPY
+    
+    majorVersion = uint8(1);
+    minorVersion = uint8(0);
+
+    % build the dict specifying data type, array order, endianness, and
+    % shape
+    dictString = '{''descr'': ''';
+    
+    if littleEndian
+        dictString = [dictString '<'];
+    else
+        dictString = [dictString '>'];
+    end
+    
+    dictString = [dictString dtypesNPY{strcmp(dtypesMatlab,dataType)} ''', '];
+    
+    dictString = [dictString '''fortran_order'': '];
+    
+    if fortranOrder
+        dictString = [dictString 'True, '];
+    else
+        dictString = [dictString 'False, '];
+    end
+    
+    dictString = [dictString '''shape'': ('];
+    
+%     if length(shape)==1 && shape==1
+%         
+%     else
+%         for s = 1:length(shape)
+%             if s==length(shape) && shape(s)==1
+%                 
+%             else
+%                 dictString = [dictString num2str(shape(s))];
+%                 if length(shape)>1 && s+1==length(shape) && shape(s+1)==1
+%                     dictString = [dictString ','];
+%                 elseif length(shape)>1 && s<length(shape)
+%                     dictString = [dictString ', '];
+%                 end            
+%             end
+%         end
+%         if length(shape)==1
+%             dictString = [dictString ','];
+%         end
+%     end
+
+    for s = 1:length(shape)
+        dictString = [dictString num2str(shape(s))];
+        if s<length(shape)
+            dictString = [dictString ', '];
+        end
+    end
+    
+    dictString = [dictString '), '];
+    
+    dictString = [dictString '}'];
+    
+    totalHeaderLength = length(dictString)+10; % 10 is length of magicString, version, and headerLength
+    
+    headerLengthPadded = ceil(double(totalHeaderLength+1)/16)*16; % the whole thing should be a multiple of 16
+                                                                  % I add 1 to the length in order to allow for the newline character
+
+	% format specification is that headerlen is little endian. I believe it comes out so using this command...
+    headerLength = typecast(int16(headerLengthPadded-10), 'uint8');
+	
+    zeroPad = zeros(1,headerLengthPadded-totalHeaderLength, 'uint8')+uint8(32); % +32 so they are spaces
+    zeroPad(end) = uint8(10); % newline character
+    
+    header = uint8([magicString majorVersion minorVersion headerLength dictString zeroPad]);
+
+end

--- a/external/npy-matlab-master/npy-matlab/datToNPY.m
+++ b/external/npy-matlab-master/npy-matlab/datToNPY.m
@@ -1,0 +1,42 @@
+
+
+function datToNPY(inFilename, outFilename, dataType, shape, varargin)
+% function datToNPY(inFilename, outFilename, shape, dataType, [fortranOrder, littleEndian])
+%
+% make a NPY file from a flat binary file, given that you know the shape,
+% dataType, ordering, and endianness of the flat binary file. 
+% 
+% The point here is you don't want to read in all the data from the
+% existing binary file - instead you can just create the appropriate header
+% and then concatenate it with the data. 
+%
+% ** completely untested
+
+if ~isempty(varargin)
+    fortranOrder = varargin{1}; % must be true/false
+    littleEndian = varargin{2}; % must be true/false
+else
+    fortranOrder = true;
+    littleEndian = true;
+end
+
+header = constructNPYheader(dataType, shape, fortranOrder, littleEndian);
+
+% ** TODO: need to put the header into a temp file instead, in case the
+% outFilename is the same as the inFilename (and then delete the temp file
+% later)
+fid = fopen(tempFilename, 'w');
+fwrite(fid, header, 'uint8');
+fclose(fid)
+
+str = computer;
+switch str
+    case {'PCWIN', 'PCWIN64'}
+        [~,~] = system(sprintf('copy /b %s+%s %s', tempFilename, inFilename, outFilename));
+    case {'GLNXA64', 'MACI64'}
+        [~,~] = system(sprintf('cat %s %s > %s', tempFilename, inFilename, outFilename));
+        
+    otherwise
+        fprintf(1, 'I don''t know how to concatenate files for your OS, but you can finish making the NPY youself by concatenating %s with %s.\n', tempFilename, inFilename);
+end
+    

--- a/external/npy-matlab-master/npy-matlab/readNPY.m
+++ b/external/npy-matlab-master/npy-matlab/readNPY.m
@@ -1,0 +1,37 @@
+
+
+function data = readNPY(filename)
+% Function to read NPY files into matlab.
+% *** Only reads a subset of all possible NPY files, specifically N-D arrays of certain data types.
+% See https://github.com/kwikteam/npy-matlab/blob/master/tests/npy.ipynb for
+% more.
+%
+
+[shape, dataType, fortranOrder, littleEndian, totalHeaderLength, ~] = readNPYheader(filename);
+
+if littleEndian
+    fid = fopen(filename, 'r', 'l');
+else
+    fid = fopen(filename, 'r', 'b');
+end
+
+try
+
+    [~] = fread(fid, totalHeaderLength, 'uint8');
+
+    % read the data
+    data = fread(fid, prod(shape), [dataType '=>' dataType]);
+
+    if length(shape)>1 && ~fortranOrder
+        data = reshape(data, shape(end:-1:1));
+        data = permute(data, [length(shape):-1:1]);
+    elseif length(shape)>1
+        data = reshape(data, shape);
+    end
+
+    fclose(fid);
+
+catch me
+    fclose(fid);
+    rethrow(me);
+end

--- a/external/npy-matlab-master/npy-matlab/readNPYheader.m
+++ b/external/npy-matlab-master/npy-matlab/readNPYheader.m
@@ -1,0 +1,69 @@
+
+
+function [arrayShape, dataType, fortranOrder, littleEndian, totalHeaderLength, npyVersion] = readNPYheader(filename)
+% function [arrayShape, dataType, fortranOrder, littleEndian, ...
+%       totalHeaderLength, npyVersion] = readNPYheader(filename)
+%
+% parse the header of a .npy file and return all the info contained
+% therein.
+%
+% Based on spec at http://docs.scipy.org/doc/numpy-dev/neps/npy-format.html
+
+fid = fopen(filename);
+
+% verify that the file exists
+if (fid == -1)
+    if ~isempty(dir(filename))
+        error('Permission denied: %s', filename);
+    else
+        error('File not found: %s', filename);
+    end
+end
+
+try
+    
+    dtypesMatlab = {'uint8','uint16','uint32','uint64','int8','int16','int32','int64','single','double', 'logical'};
+    dtypesNPY = {'u1', 'u2', 'u4', 'u8', 'i1', 'i2', 'i4', 'i8', 'f4', 'f8', 'b1'};
+    
+    
+    magicString = fread(fid, [1 6], 'uint8=>uint8');
+    
+    if ~all(magicString == [147,78,85,77,80,89])
+        error('readNPY:NotNUMPYFile', 'Error: This file does not appear to be NUMPY format based on the header.');
+    end
+    
+    majorVersion = fread(fid, [1 1], 'uint8=>uint8');
+    minorVersion = fread(fid, [1 1], 'uint8=>uint8');
+    
+    npyVersion = [majorVersion minorVersion];
+    
+    headerLength = fread(fid, [1 1], 'uint16=>uint16');
+    
+    totalHeaderLength = 10+headerLength;
+    
+    arrayFormat = fread(fid, [1 headerLength], 'char=>char');
+    
+    % to interpret the array format info, we make some fairly strict
+    % assumptions about its format...
+    
+    r = regexp(arrayFormat, '''descr''\s*:\s*''(.*?)''', 'tokens');
+    dtNPY = r{1}{1};    
+    
+    littleEndian = ~strcmp(dtNPY(1), '>');
+    
+    dataType = dtypesMatlab{strcmp(dtNPY(2:3), dtypesNPY)};
+        
+    r = regexp(arrayFormat, '''fortran_order''\s*:\s*(\w+)', 'tokens');
+    fortranOrder = strcmp(r{1}{1}, 'True');
+    
+    r = regexp(arrayFormat, '''shape''\s*:\s*\((.*?)\)', 'tokens');
+    shapeStr = r{1}{1}; 
+    arrayShape = str2num(shapeStr(shapeStr~='L'));
+
+    
+    fclose(fid);
+    
+catch me
+    fclose(fid);
+    rethrow(me);
+end

--- a/external/npy-matlab-master/npy-matlab/writeNPY.m
+++ b/external/npy-matlab-master/npy-matlab/writeNPY.m
@@ -1,0 +1,25 @@
+
+
+function writeNPY(var, filename)
+% function writeNPY(var, filename)
+%
+% Only writes little endian, fortran (column-major) ordering; only writes
+% with NPY version number 1.0.
+%
+% Always outputs a shape according to matlab's convention, e.g. (10, 1)
+% rather than (10,).
+
+
+shape = size(var);
+dataType = class(var);
+
+header = constructNPYheader(dataType, shape);
+
+fid = fopen(filename, 'w');
+fwrite(fid, header, 'uint8');
+fwrite(fid, var, dataType);
+fclose(fid);
+
+
+end
+

--- a/shared/readSpikeRaw_Phy.m
+++ b/shared/readSpikeRaw_Phy.m
@@ -1,0 +1,140 @@
+function [SpikeRaw] = readSpikeRaw_Phy(cfg,force,varargin)
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% [SpikeRaw] = readSpikeRaw_Phy(cfg,force,varargin)
+% 
+% Read SpykingCircus analysis results (spike times, templates, amplitudes).
+% Data must have been converted for Phy GUI, with  parameter prelabelling = True.
+% https://spyking-circus.readthedocs.io/en/latest/advanced/extras.html#converting
+% 
+% If data were checked with Phy, neurons are filtered and only the 'good' or
+% 'mua' are loaded. Otherwise (data never opened with Phy), all neurons are 
+% loaded.
+%
+% ### Necessary input:
+% cfg.prefix            = prefix to output files
+% cfg.datasavedir       = data directory of Phy converted results
+% cfg.circus.postfix    = postfix in the name of spike data, if need to
+%                         separate several analysis.
+% cfg.circus.channel    = analyzed-electrode names
+% force                 = whether to redo analyses or read previous save
+%                         (true/false)
+%
+% ### Output:
+% SpikeRaw              = raw spike data in FieldTrip raw spike data structure
+% 
+% Dependencies : 
+% - npy-matlab (https://github.com/kwikteam/npy-matlab)
+% - Fieldtrip
+%
+% Paul Baudin (paul.baudin@live.fr)
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+if isempty(varargin) || strcmp(varargin{1},'all')
+    parts_to_read = 1:size(cfg.directorylist,2);
+else
+    parts_to_read = varargin{1};
+end
+
+fname = fullfile(cfg.datasavedir,[cfg.prefix,'SpikeRaw_Phy', cfg.circus.postfix, '.mat']);
+
+if exist(fname,'file') && force == false
+    fprintf('Load precomputed SpikeRaw data\n');
+    load(fname,'SpikeRaw');
+    return
+end
+
+for ipart = parts_to_read
+    
+    
+    %% find spiking-circus output path, which is based on the name of the first datafile
+    
+    datadir             = fullfile(cfg.datasavedir,cfg.prefix(1:end-1),['p',num2str(ipart)]);
+    phydir_temp         = fullfile(datadir,'SpykingCircus',[cfg.prefix,'p',num2str(ipart),'-multifile-',cfg.circus.channel{1}(1:end-2),'*',cfg.circus.postfix,'.GUI']);
+    temp                = dir(phydir_temp);
+    if isempty(temp)
+        error('Could not find Phy-converted Spyking-Circus results: %s\n',phydir);
+    end
+    phydir              = fullfile(temp.folder,temp.name);
+    datafile            = [temp.name(1 : end - length(cfg.circus.postfix) - length('.GUI')), '.ncs'];
+    
+    %% load spike data
+    
+    fprintf('Loading spike data from %s\n', phydir);
+    
+    phydata.amplitudes              = readNPY(fullfile(phydir,'amplitudes.npy'));      %amplitude of each spike (relative to template ?)
+    phydata.cluster_group           = tdfread(fullfile(phydir,'cluster_group.tsv'));   %phy classification.
+    phydata.spike_times             = readNPY(fullfile(phydir,'spike_times.npy'));     %each timing of any spike, in samples
+    phydata.spike_templates         = readNPY(fullfile(phydir,'spike_templates.npy')); %for each timing, which (non merged) template. Include the garbage templates : the last ones, one per electrode
+    phydata.templates               = readNPY(fullfile(phydir,'templates.npy'));       %templates waveforms, before merging (merging in phy change clusters but not templates)
+    phydata.templates               = permute(phydata.templates, [1 3 2]);             %permute to be consistent to SpikeRaw struct from MATLAB data
+    
+    %2 files created by Phy, not Spyking-Circus. Not here if data were not
+    %opened at least once with Phy :
+    if exist(fullfile(phydir,'cluster_info.tsv')) && exist(fullfile(phydir,'spike_clusters.npy'))
+        ischecked                   = true;
+        phydata.cluster_info        = tdfread(fullfile(phydir,'cluster_info.tsv'));%id, amp, ch, depth, fr, group, n_spikes, sh
+        phydata.spike_clusters      = readNPY(fullfile(phydir,'spike_clusters.npy')); %for each timing, which (merged) cluster. Include garbage clusters
+    else
+        ischecked                    = false;
+        warning('Data were not checked on Phy : loading all templates');
+    end
+    
+    % take the first concatinated channel to extract the timestamps
+    hdr_fname                        = fullfile(datadir,datafile);
+    hdr                              = ft_read_header(hdr_fname);
+    % timestamps  = ft_read_data(hdr_fname,'timestamp','true');
+    timestamps                       =  (0:hdr.nSamples-1) * hdr.TimeStampPerSample; % calculate timemstamps myself, as this is much faster
+    
+    %% reorganize data to make a structure compatible with Fieldtrip
+    
+    %filter data if checked on Phy. Otherwise load all templates
+    if ischecked     
+        cluster_list   = phydata.cluster_group.cluster_id(phydata.cluster_group.group(:,1) ~= 'n')'; %only good, or mua clusters (not noise)
+    else
+        cluster_list   = unique(phydata.spike_templates)';
+    end
+    
+    for icluster = 1:size(cluster_list,2)
+        
+        %find spike time indexes for each cluster
+        timings_idx                                     = [];
+        if ischecked
+            timings_idx                                 = phydata.spike_clusters == cluster_list(icluster);
+        else
+            timings_idx                                 = phydata.spike_templates == cluster_list(icluster);
+        end
+        
+        %add data of selected timings
+        SpikeRaw{ipart}.label{icluster}                 = sprintf('cluster_%d',cluster_list(icluster));
+        SpikeRaw{ipart}.samples{icluster}               = phydata.spike_times(timings_idx)';
+        SpikeRaw{ipart}.amplitude{icluster}             = phydata.amplitudes(timings_idx)';
+        SpikeRaw{ipart}.timestamp{icluster}             = timestamps(SpikeRaw{ipart}.samples{icluster});
+        
+        %Phy group info (good, mua)
+        if ischecked
+            SpikeRaw{ipart}.cluster_group{icluster}         = phydata.cluster_group.group(phydata.cluster_group.cluster_id == cluster_list(icluster),:); 
+        end
+        
+        %add templates
+        %Template dimensions : 1 cluster, 2 electrode, 3 y value
+        cluster_templates                               = unique(phydata.spike_templates(timings_idx))+1; %+1 because template begins at zero but index in phyinfos.templates begins at 1
+        SpikeRaw{ipart}.template{icluster}              = phydata.templates(cluster_templates,:,:);%all template waveforms merged in this cluster
+        if ischecked
+            SpikeRaw{ipart}.template_maxchan(icluster)  = phydata.cluster_info.ch(phydata.cluster_info.id == cluster_list(icluster));
+        else
+            [~,imaxchan] = max(mean(abs(SpikeRaw{ipart}.template{icluster}),3));
+            SpikeRaw{ipart}.template_maxchan(icluster)  = imaxchan - 1; %-1 because chans idx begin at zero with Phy
+        end
+    
+    end
+    
+    clear timestamps
+    
+end % ipart
+
+save(fname,'SpikeRaw');
+
+end


### PR DESCRIPTION
Hi Stephen,
Here is what I used to load directly Phy data without need of re-converting into Spyking-Circus results (which by the way do not work if I merged clusters on Phy).

1/ the external MATLAB functions I used to load .npy files. I put it in the external folder.

2/ readSpikeRaw_Phy.m : the function I made to load and organize data. The SpikeRaw output is exactly the same as the one created previously while reading of non-converted Spyking Circus results. Except for the templates : I put one field per unit instead of one array with one line per unit. This allows me to keep the waveforms of the different templates I merged for each unit.

Paul