### PR TITLE
Read lfp

### DIFF
--- a/shared/readLFP.m
+++ b/shared/readLFP.m
@@ -55,13 +55,18 @@ if exist(fname_out,'file') && force == false
     fprintf('*** Loading precomputed LFP data ***\n');
     fprintf('************************************\n\n');
     load(fname_out,'LFP');
+    return
 else
     fprintf('********************************\n');
     fprintf('*** (re-) computing LFP data ***\n');
     fprintf('********************************\n\n');
+end
     
     % get file format 
     [isNeuralynx, isMicromed, isBrainvision] = get_data_format(cfg);
+    
+    % initialize LFP, to return empty array in case there is no LFP to load
+    LFP = [];
 
     % loop over parts within subject
     for ipart = 1:length(MuseStruct)
@@ -123,28 +128,19 @@ else
                     cfgtemp.bpfreq          = ft_getopt(cfg.LFP, 'bpfreq', []);
                     cfgtemp.bsfreq          = ft_getopt(cfg.LFP, 'bsfreq', []);                        
                     dat                     = ft_preprocessing(cfgtemp,dat);  
-                    
-                    %%%%% PAUL: please simplify logic here; why not just check
-                    %%%%% for cfg.EMG, and place channelnames there? This
-                    %%%%% is in any case very confusing
-                    
+                
                     % append EMG data (if any)
-                    if isfield(cfg.LFP, 'emg') 
-
-                        if isfield(cfg.EMG, 'reref') && strcmp(cfg.EMG.reref, 'yes')
-                            cfgtemp                   = [];
-                            cfgtemp.channel           = {cfg.LFP.emg{imarker}, cfg.EMG.refchannel{1}}; % load the emg associated with eeg marker, and the ref
-                            cfgtemp.dataset           = fname;
-                            cfgtemp.reref             = cfg.EMG.reref;
-                            cfgtemp.rerefmethod       = cfg.EMG.rerefmethod;
-                            cfgtemp.refchannel        = cfg.EMG.refchannel;
-                            data_EMG                  = ft_preprocessing(cfgtemp);
-                        else
-                            cfgtemp                   = [];
-                            cfgtemp.channel           = cfg.LFP.emg{imarker}; % load only the emg associated with eeg marker
-                            cfgtemp.dataset           = fname;
-                            data_EMG                  = ft_preprocessing(cfgtemp);
-                        end
+                    if isMicromed || isBrainvision %not adapted for nlx data (1 file per electrode) for now
+                        
+                        cfg.EMG = ft_getopt(cfg, 'EMG', []);
+                        
+                        cfgtemp                   = [];
+                        cfgtemp.channel           = {cfg.LFP.emg{imarker}, ft_getopt(cfg.EMG, 'refchannel', [])}; % load the emg associated with eeg marker, and the ref if any
+                        cfgtemp.dataset           = fname;
+                        cfgtemp.reref             = ft_getopt(cfg.EMG, 'reref', 'no');
+                        cfgtemp.rerefmethod       = ft_getopt(cfg.EMG, 'rerefmethod', []);
+                        cfgtemp.refchannel        = ft_getopt(cfg.EMG, 'refchannel', []);
+                        data_EMG                  = ft_preprocessing(cfgtemp);
                         
                         % filtering
                         cfgtemp                 = [];
@@ -162,8 +158,8 @@ else
                         cfgtemp                 = [];
                         cfgtemp.keepsampleinfo  = 'yes';
                         dat                     = ft_appenddata(cfgtemp, dat, data_EMG);
-                        
                     end
+                    
                     
                     % downsample data and correct baseline
                     if isfield(cfg.LFP,'resamplefs')
@@ -178,7 +174,9 @@ else
                         end  
                         dat                             = ft_resampledata(cfgtemp,dat);
                     end        
-                                 
+                      
+                    fsample = dat.fsample; %store this info for output LFP
+                    
                     % create trial segmentation common to resampled
                     % data. Neuralynx : same markers for all files
                     % of one dir.
@@ -250,6 +248,9 @@ else
                     cfgtemp.trl(:,4)                = trialnr;
                     cfgtemp.trl(:,6)                = idir;
                     cfgtemp.trl(:,7)                = Stage;
+                    cfgtemp.trl(:,8)                = Startsample;
+                    cfgtemp.trl(:,9)                = Endsample;
+                    cfgtemp.trl(:,10)               = Offset;
                     cfgtemp.trl                     = cfgtemp.trl(Startsample > 0 & Endsample < length(dat.trial{1}),:); % don't read before BOF or after EOF
                     filedat{ifile}                  = ft_redefinetrial(cfgtemp,dat);
                     clear dat
@@ -275,6 +276,7 @@ else
                 
                 % concatinate data of different datasets (over trials)
                 LFP{ipart}{imarker} = ft_appenddata([],dirdat{find(hasmarker)});
+                LFP{ipart}{imarker}.fsample = fsample;
                 clear dirdat*              
             else
                 LFP{ipart}{imarker} = [];
@@ -285,8 +287,7 @@ else
         
     end % ipart
    
-end
-
+    
 if write
     save(fname_out,'LFP','-v7.3');
 end

--- a/shared/readLFP.m
+++ b/shared/readLFP.m
@@ -66,7 +66,7 @@ end
     [isNeuralynx, isMicromed, isBrainvision] = get_data_format(cfg);
     
     % initialize LFP, to return empty array in case there is no LFP to load
-    LFP = [];
+    LFP = {};
 
     % loop over parts within subject
     for ipart = 1:length(MuseStruct)

--- a/shared/writeSpykingCircus.m
+++ b/shared/writeSpykingCircus.m
@@ -60,16 +60,23 @@ else
                     fname{1}                        = cfgtemp.dataset;
                     dirdat{idir}                    = ft_read_neuralynx_interp(fname);
                     
+                    %rereferencing, if required
                     if strcmp(cfg.circus.reref,'yes')
-                        temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan,'.ncs']));
-                        cfgtemp                     = [];
-                        cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
-                        fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
-                        clear fname
-                        fname{1}                    = cfgtemp.dataset;
-                        refdat                      = ft_read_neuralynx_interp(fname);
-                        dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
-                        clear refdat
+                        for iref = 1:size(cfg.circus.refchan, 2)
+                            %For each reference channel, search if the
+                            %current channel has to be rereferenced
+                            if any(strcmp(cfg.circus.channel{ichan},cfg.circus.chanstoref{iref}))
+                                temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan{iref},'.ncs']));
+                                cfgtemp                     = [];
+                                cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
+                                fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
+                                clear fname
+                                fname{1}                    = cfgtemp.dataset;
+                                refdat                      = ft_read_neuralynx_interp(fname);
+                                dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
+                                clear refdat
+                            end
+                        end
                     end
                     
                     % creation of artefacts caused by large offsets

--- a/shared/writeSpykingCircus.m
+++ b/shared/writeSpykingCircus.m
@@ -60,23 +60,16 @@ else
                     fname{1}                        = cfgtemp.dataset;
                     dirdat{idir}                    = ft_read_neuralynx_interp(fname);
                     
-                    %rereferencing, if required
                     if strcmp(cfg.circus.reref,'yes')
-                        for iref = 1:size(cfg.circus.refchan, 2)
-                            %For each reference channel, search if the
-                            %current channel has to be rereferenced
-                            if any(strcmp(cfg.circus.channel{ichan},cfg.circus.chanstoref{iref}))
-                                temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan{iref},'.ncs']));
-                                cfgtemp                     = [];
-                                cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
-                                fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
-                                clear fname
-                                fname{1}                    = cfgtemp.dataset;
-                                refdat                      = ft_read_neuralynx_interp(fname);
-                                dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
-                                clear refdat
-                            end
-                        end
+                        temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan,'.ncs']));
+                        cfgtemp                     = [];
+                        cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
+                        fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
+                        clear fname
+                        fname{1}                    = cfgtemp.dataset;
+                        refdat                      = ft_read_neuralynx_interp(fname);
+                        dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
+                        clear refdat
                     end
                     
                     % creation of artefacts caused by large offsets

--- a/shared/writeSpykingCircusParameters.m
+++ b/shared/writeSpykingCircusParameters.m
@@ -26,7 +26,7 @@ function writeSpykingCircusParameters(cfg)
 cfg.circus.part_list                = ft_getopt(cfg.circus, 'part_list', 'all');
 
 if strcmp(cfg.circus.part_list, 'all')
-    cfg.circus.part_list = 1:size(MuseStruct,2);
+    cfg.circus.part_list = 1:size(cfg.directorylist,2);
 end
 
 [p, ~, ~]               = fileparts(mfilename('fullpath'));


### PR DESCRIPTION
Some small modifications about readLFP.m :

  -  With the same logic that you use ‘continue’ in for loops, I think ‘return’ can improve readability when use with the ‘force’ variable (avoiding an ‘if’ statement for nearly the whole file).
 -   It is nice for how I deal with dtx experiments (where I have to load LFP) vs control experiment (where I do not load LFP for now), to be able to launch readLFP even if there are no LFP data to load (ie cfg.LFP.name is empty), and make it return and empty array. For that I need to initialise LFP array at the begining of the file, so it is outputed if nothing else is done.
 -   I corrected the EMG part as you asked. The ft_getopt is very helpful to make a clearer code for data with different needs in cfg fields.
 -   I added fsample in the outputed LFP as I think it is easier to do it here where the header is already loaded, whereas to re-search for it later
 -   I added some trialinfos columns. It allows me to easier find later where the trials are located in the initial neuralynx file. I use it to search for trials which intersect BAD markers much more easily : no need to re_use cfg.muse.startend, and, find trials location regardless of how the trials where defined (see removetrials_MuseMarkers.m in a later pull request).

Let me know if you have any improvement or better ideas for this :)