### PR TITLE
Alignxcorr

### DIFF
--- a/shared/alignMuseMarkersXcorr.m
+++ b/shared/alignMuseMarkersXcorr.m
@@ -47,7 +47,7 @@ else
     cfgtemp                 = rmfield(cfg,'LFP');
     cfgtemp.LFP.name        = cfg.align.name;
     cfgtemp.LFP.channel     = cfg.align.channel;
-    [LFP]                   = readLFP(cfgtemp, MuseStruct, true, false);
+    [LFP]                   = readLFP(cfgtemp, MuseStruct, false);
     
     for ipart = 1:size(cfg.directorylist,2)
         
@@ -95,7 +95,8 @@ else
             set(gca,'xtick',[]);
             
             subplot(2,5,6);
-            plot(cumsum(repmat(dat.time{1},1,d(1))),LFP_concatinated(~rejected,:)');
+%             plot(cumsum(repmat(dat.time{1},1,d(1))),LFP_concatinated(~rejected,:)');
+            plot(dat.time{1},LFP_concatinated(~rejected,:)');
             axis tight
             
             subplot(2,5,2);
@@ -104,7 +105,8 @@ else
             set(gca,'xtick',[]);
             
             subplot(2,5,7);
-            plot(cumsum(repmat(dat.time{1},1,d(1))),LFP_concatinated(rejected,:)');
+%             plot(cumsum(repmat(dat.time{1},1,d(1))),LFP_concatinated(rejected,:)');
+            plot(dat.time{1},LFP_concatinated(rejected,:)');
             axis tight
             
             subplot(2,5,3);
@@ -113,7 +115,8 @@ else
             set(gca,'xtick',[]);
             
             subplot(2,5,8);
-            plot(cumsum(repmat(dat.time{1},1,d(1))),shifted(~rejected,:)');
+%             plot(cumsum(repmat(dat.time{1},1,d(1))),shifted(~rejected,:)');
+            plot(dat.time{1},shifted(~rejected,:)');
             axis tight
             
             subplot(2,5,4);
@@ -121,7 +124,8 @@ else
             title('Misaligned');
             set(gca,'xtick',[]);
             subplot(2,5,9);
-            plot(cumsum(repmat(dat.time{1},1,d(1))),shifted(rejected,:)');
+%             plot(cumsum(repmat(dat.time{1},1,d(1))),shifted(rejected,:)');
+            plot(dat.time{1},shifted(rejected,:)');
             axis tight
             
             subplot(2,5,5);
@@ -130,7 +134,8 @@ else
             set(gca,'xtick',[]);
             
             subplot(2,5,10);
-            plot(cumsum(repmat(dat.time{1},1,d(1))),shifted_clean_z');
+%             plot(cumsum(repmat(dat.time{1},1,d(1))),shifted_clean_z');
+            plot(dat.time{1},shifted_clean_z');
             axis tight
             
             set(fig,'PaperOrientation','landscape');
@@ -179,4 +184,3 @@ else
     % save data
     save(fname,'MuseStruct');
 end
-

--- a/shared/writeSpykingCircus.m
+++ b/shared/writeSpykingCircus.m
@@ -60,16 +60,23 @@ else
                     fname{1}                        = cfgtemp.dataset;
                     dirdat{idir}                    = ft_read_neuralynx_interp(fname);
                     
+                    %rereferencing, if required
                     if strcmp(cfg.circus.reref,'yes')
-                        temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan,'.ncs']));
-                        cfgtemp                     = [];
-                        cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
-                        fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
-                        clear fname
-                        fname{1}                    = cfgtemp.dataset;
-                        refdat                      = ft_read_neuralynx_interp(fname);
-                        dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
-                        clear refdat
+                        for iref = 1:size(cfg.circus.refchan, 2)
+                            %For each reference channel, search if the
+                            %current channel has to be rereferenced
+                            if any(strcmp(cfg.circus.channel{ichan},cfg.circus.chanstoref{iref}))
+                                temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan{iref},'.ncs']));
+                                cfgtemp                     = [];
+                                cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
+                                fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
+                                clear fname
+                                fname{1}                    = cfgtemp.dataset;
+                                refdat                      = ft_read_neuralynx_interp(fname);
+                                dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
+                                clear refdat
+                            end
+                        end
                     end
                     
                     % creation of artefacts caused by large offsets

--- a/shared/writeSpykingCircus.m
+++ b/shared/writeSpykingCircus.m
@@ -60,23 +60,16 @@ else
                     fname{1}                        = cfgtemp.dataset;
                     dirdat{idir}                    = ft_read_neuralynx_interp(fname);
                     
-                    %rereferencing, if required
                     if strcmp(cfg.circus.reref,'yes')
-                        for iref = 1:size(cfg.circus.refchan, 2)
-                            %For each reference channel, search if the
-                            %current channel has to be rereferenced
-                            if any(strcmp(cfg.circus.channel{ichan},cfg.circus.chanstoref{iref}))
-                                temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan{iref},'.ncs']));
-                                cfgtemp                     = [];
-                                cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
-                                fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
-                                clear fname
-                                fname{1}                    = cfgtemp.dataset;
-                                refdat                      = ft_read_neuralynx_interp(fname);
-                                dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
-                                clear refdat
-                            end
-                        end
+                        temp                        = dir(fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir},['*',cfg.circus.refchan,'.ncs']));
+                        cfgtemp                     = [];
+                        cfgtemp.dataset             = fullfile(cfg.rawdir,cfg.directorylist{ipart}{idir}, temp.name);
+                        fprintf('LOADING (reference): %s\n',cfgtemp.dataset);
+                        clear fname
+                        fname{1}                    = cfgtemp.dataset;
+                        refdat                      = ft_read_neuralynx_interp(fname);
+                        dirdat{idir}.trial{1}       = dirdat{idir}.trial{1} - refdat.trial{1};
+                        clear refdat
                     end
                     
                     % creation of artefacts caused by large offsets

--- a/shared/writeSpykingCircusParameters.m
+++ b/shared/writeSpykingCircusParameters.m
@@ -26,7 +26,7 @@ function writeSpykingCircusParameters(cfg)
 cfg.circus.part_list                = ft_getopt(cfg.circus, 'part_list', 'all');
 
 if strcmp(cfg.circus.part_list, 'all')
-    cfg.circus.part_list = 1:size(MuseStruct,2);
+    cfg.circus.part_list = 1:size(cfg.directorylist,2);
 end
 
 [p, ~, ~]               = fileparts(mfilename('fullpath'));


### PR DESCRIPTION
Hi Stephen. You may  not want to pull those modifications, it is more to show you issues I had :
-	In your use of readLFP, I think you have still and old version, so I removed one paramter which is not here in the new version. I set force as false, as for my data with big LFP it saves lot of time if lfp is stored on the disk (besides on the cluster, the speed for loading/saving data is theorically 50 times superior than on our local computers)
-	Why do you use cumsum and repmat for the x values of the output plots ? For my data, it creates non-linear x intervals and I don’t know what I see on the plots, but it do not look at the slow waves at all. If I use only the time of the Fieldtrip LFP (as I did in this pull request) I see an overdraw of all the slow waves. 

Thanks !
