### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _ICM, Paris_
  * Reduce repetition/duplication of code (and work)
  * Backup and version control, and a way to update between computers/servers.
  * Single solution for interfacing with in-house (MUSE) and external software ([Spyking-Circus](https://github.com/spyking-circus)).
- * Synchronization between different recording systems and their annotation systems (NeuraLynx, MicroMed and DeltaMed)
+ * Synchronization between different recording systems and their annotation systems (NeuraLynx, MicroMed and Brainvision)
  * Facilitate use of [FieldTrip](https://github.com/fieldtrip/fieldtrip).
  * Facilitate documentation and publication of methodology.
 


### PR DESCRIPTION
I changed DeltaMed to Brainvision. Indeed, to use with Muse and Fieldtrip, I have to convert Deltamed data to Brainvision data. For that, I use a library from Deltamed, which is confidentiel (we have a specific code for the ICM to unlock this library). So I did not put this conversion scripts into Epicode. This is why what I really use with EpiCode is Brainvision data.