### PR TITLE
update shared spikes functions

### DIFF
--- a/shared/readSpikeRaw_Phy.m
+++ b/shared/readSpikeRaw_Phy.m
@@ -97,7 +97,7 @@ for ipart = cfg.circus.part_list
         
         temp    = dir(fullfile(datadir, 'SpykingCircus', '*.GUI'));
         if isempty(temp)
-            error('Could not find Phy-converted Spyking-Circus results: %s\n', phydir);
+            error('Could not find Phy-converted Spyking-Circus results in %s\n', fullfile(datadir, 'SpykingCircus', '*.GUI'));
         else
             phydir = fullfile(temp.folder, temp.name);
         end

--- a/shared/readSpikeTrials_MuseMarkers.m
+++ b/shared/readSpikeTrials_MuseMarkers.m
@@ -77,6 +77,8 @@ for ipart = cfg.circus.part_list
     clear Trials
     for markername = string(cfg.name)
         
+        SpikeTrials{ipart}.(markername) = []; %initialize to avoid bug in case no marker are found and need to output empty structure
+        
         % clock time of each event
         clocktimes = [];
         for ifile = 1 : size(MuseStruct{ipart}, 2)
@@ -255,6 +257,10 @@ for ipart = cfg.circus.part_list
             trlend   = SpikeTrials{ipart}.(markername).trialinfo.endsample(ievent) / hdr.Fs;
             
             for idir = 1 : size(MuseStruct{ipart}, 2)
+                if ~ismember(idir,dir_list)
+                    continue
+                end
+                
                 length_previousdir = dir_offset(dir_list == idir) / hdr.Fs;
                 
                 if ~isfield(MuseStruct{ipart}{idir}.markers, 'BAD__START__')
@@ -281,7 +287,7 @@ for ipart = cfg.circus.part_list
                 %it must end before the trial
                 if artend(idx) > trlstart
                     artefact(ievent) = true;
-                    artefact_length(ievent) = artend(idx) - artstart(idx);
+                    artefact_length(ievent) = artend(idx) - artstart(idx) + artefact_length(ievent); %in case several artefacts intersect this trial
                 end
                 
                 %first artstart after trial start must begin after
@@ -292,7 +298,7 @@ for ipart = cfg.circus.part_list
                 end
                 if artstart(idx) < trlend
                     artefact(ievent) = true;
-                    artefact_length(ievent) = artend(idx) - artstart(idx);
+                    artefact_length(ievent) = artend(idx) - artstart(idx) + artefact_length(ievent); %in case several artefacts intersect this trial
                 end
                 
             end
@@ -334,7 +340,7 @@ for ipart = cfg.circus.part_list
                         continue
                     else
                         artefact(ievent) = true;
-                        artefact_length(ievent) = seconds(artend - artstart);
+                        artefact_length(ievent) = seconds(artend - artstart) + artefact_length(ievent); %in case several artefacts intersect this trial
                     end
                     
                 end % iart

--- a/shared/readSpikeTrials_windowed.m
+++ b/shared/readSpikeTrials_windowed.m
@@ -162,6 +162,10 @@ for ipart = cfg.circus.part_list
                 if ~isfield(MuseStruct{ipart}{idir}.markers, char(markername))
                     continue
                 end
+                
+                if ~isfield(MuseStruct{ipart}{idir}.markers.(char(markername)), 'synctime')
+                    continue
+                end
 
                 for iIED = 1 : size(MuseStruct{ipart}{idir}.markers.(markername).synctime, 2)
 
@@ -194,7 +198,8 @@ for ipart = cfg.circus.part_list
     end % ievent
     ft_progress('close');
 
-    artefact = false(size(SpikeTrials{ipart}.window.trialinfo, 1), 1);
+    artefact        = false(size(SpikeTrials{ipart}.window.trialinfo, 1), 1);
+    artefact_length = zeros(size(SpikeTrials{ipart}.window.trialinfo, 1), 1);
     ft_progress('init','text')
     for ievent = 1 : size(SpikeTrials{ipart}.window.trialinfo, 1)
         ft_progress(ievent/size(SpikeTrials{ipart}.window.trialinfo, 1), 'Looking for overlap with artefacts in trial %d of %d \n', ievent, size(SpikeTrials{ipart}.window.trialinfo, 1))
@@ -224,14 +229,18 @@ for ipart = cfg.circus.part_list
                         continue
                     else
                         artefact(ievent) = true;
+                        artefact_length(ievent) = seconds(artend - artstart) + artefact_length(ievent);
                     end
+                    
+                    
                 end % ihyp
         end % idir
     end % ievent
     ft_progress('close');
 
     % add artefact to trialinfo
-    SpikeTrials{ipart}.window.trialinfo.artefact = artefact;
+    SpikeTrials{ipart}.window.trialinfo.artefact        = artefact;
+    SpikeTrials{ipart}.window.trialinfo.artefact_length = artefact_length;
 
 end % ipart
 

--- a/shared/spikeTrialStats.m
+++ b/shared/spikeTrialStats.m
@@ -3,8 +3,8 @@ function [stats] = spikeTrialStats(cfg, SpikeTrials, force, postfix)
 % SPIKERATESTATSEVENTS calculates and plots spike statistics
 %
 % use as
-%   spikeratestatsEvents(cfg, SpikeRaw, SpikeTrials, force, varargin)
-
+%   [stats] = spikeTrialStats(cfg, SpikeTrials, force, postfix)
+% 
 % This file is part of EpiCode, see
 % http://www.github.com/stephenwhitmarsh/EpiCode for documentation and details.
 %
@@ -20,6 +20,8 @@ function [stats] = spikeTrialStats(cfg, SpikeTrials, force, postfix)
 %
 %   You should have received a copy of the GNU General Public License
 %   along with EpiCode. If not, see <http://www.gnu.org/licenses/>.
+
+cfg.spike.RPV = ft_getopt(cfg.spike, 'RPV', 0.001);
 
 fname = fullfile(cfg.datasavedir, [cfg.prefix, 'spikestats-', postfix, '.mat']);
 if exist(fname, 'file') && force == false
@@ -82,6 +84,10 @@ for ipart = 1 : size(SpikeTrials, 2)
             stats{ipart}.(markername){itemp}.isi_avg        = isi_temp.avg(itemp, :);
             stats{ipart}.(markername){itemp}.isi_avg_time   = isi_temp.time;
             stats{ipart}.(markername){itemp}.label          = isi_temp.label{itemp};
+            refr = sum(stats{ipart}.(markername){itemp}.isi < cfg.spike.RPV);
+            tot  = length((stats{ipart}.(markername){itemp}.isi));
+            stats{ipart}.(markername){itemp}.RPV = refr/tot;
+            
             % spike autocorr
             cfgtemp              = [];
             cfgtemp.spikechannel = SpikeTrials{ipart}.(markername).label{itemp};

--- a/shared/spikeWaveformStats.m
+++ b/shared/spikeWaveformStats.m
@@ -128,6 +128,7 @@ for ipart = 1:size(SpikeWaveforms)
             end %isempty
             
             %store for output
+            stats{ipart}.(markername).label{icluster}          = SpikeWaveforms{ipart}.(markername){icluster}.label{1};
             if ok
                 stats{ipart}.(markername).waveformavg{icluster}    = waveformavg;
                 stats{ipart}.(markername).amplitude.val(icluster)  = amplitude.val;

--- a/shared/spikeWaveformStats.m
+++ b/shared/spikeWaveformStats.m
@@ -1,0 +1,166 @@
+function 	stats = spikeWaveformStats(cfg, SpikeWaveforms, force)
+
+% SPIKEWAVEFORMSTATS computes average and variance of the spike waveform.
+% Then, the average is interpolated and the following parameters are 
+% computed : amplitude, halfwidth, peaktrough and trouhpeak. 
+% Input spike waveform data is get from readSpikeWaveforms.m. 
+% 
+% Use as :
+%   stats = spikeWaveformStats(cfg, SpikeWaveforms, force)
+% 
+% Note :
+% - spikes must be peak-aligned to zero (automatically done by SpyKING-Circus)
+% - spikes can be positive or negative
+% 
+% This file is part of EpiCode, see
+% http://www.github.com/stephenwhitmarsh/EpiCode for documentation and details.
+%
+%   EpiCode is free software: you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation, either version 3 of the License, or
+%   (at your option) any later version.
+%
+%   EpiCode is distributed in the hope that it will be useful,
+%   but WITHOUT ANY WARRANTY; without even the implied warranty of
+%   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%   GNU General Public License for more details.
+%
+%   You should have received a copy of the GNU General Public License
+%   along with EpiCode. If not, see <http://www.gnu.org/licenses/>.
+
+
+fname_out = fullfile(cfg.datasavedir, strcat(cfg.prefix, 'spikewaveformstats.mat'));
+
+if exist(fname_out, 'file') && force == false
+    fprintf('*** Loading precomputed spike waveform stats ***\n');
+    load(fname_out, 'stats');
+    return
+else
+    fprintf('*** (re-) computing spike waveform stats ***\n');
+end
+
+% add external/intersections path if not already
+mfile_name          = mfilename('fullpath');
+pathstr             = fileparts(fileparts(mfile_name));
+pathCell            = regexp(path, pathsep, 'split');
+if ispc  % Windows is not case-sensitive
+    onPath = any(strcmpi(fullfile(pathstr, ['external', filesep, 'intersections']), pathCell));
+else
+    onPath = any(strcmp(fullfile(pathstr, ['external', filesep, 'intersections']), pathCell));
+end
+if ~onPath
+    addpath(fullfile(pathstr, ['external', filesep, 'intersections']));
+end
+
+
+for ipart = 1:size(SpikeWaveforms)
+    for markername = string(fieldnames(SpikeWaveforms{ipart}))'
+        ft_progress('init', 'text');
+        for icluster = 1:size(SpikeWaveforms{ipart}.(markername), 2)
+            
+            ft_progress(0, 'Compute waveform for part %d, %s, cluster %d/%d', ipart, char(markername), icluster, size(SpikeWaveforms{ipart}.(markername), 2));
+            ok = true;
+            
+            if ~isempty(SpikeWaveforms{ipart}.(markername){icluster})
+               
+                %average waveform
+                evalc('waveformavg = ft_timelockanalysis([], SpikeWaveforms{ipart}.(markername){icluster});');%remove text output
+                
+                %interpolate the averaged waveform to have more precise values
+                time_temp = linspace(waveformavg.time(1),waveformavg.time(end),1000);
+                avg_temp  = pchip(waveformavg.time,waveformavg.avg,time_temp);
+                waveformavg.time = time_temp;
+                waveformavg.avg  = avg_temp;
+                %scatter(waveformavg.time, waveformavg.avg, '.');
+                
+                %search if AP is positive or negative
+                flip = sign(waveformavg.avg(nearest(waveformavg.time, 0)));
+                
+                %amplitude
+                bl               = min(waveformavg.avg.*flip);
+                [peak, peak_idx] = max(waveformavg.avg.*flip);
+                amplitude.val    = peak-bl;
+                amplitude.x      = waveformavg.time(peak_idx);
+                amplitude.y      = waveformavg.avg(peak_idx);
+                %scatter(amplitude.x, amplitude.y, 'xk');
+                
+                %halfwidth
+                halfamp     = bl+(peak-bl)/2;
+                x1 = waveformavg.time;
+                y1 = waveformavg.avg;
+                x2 = x1;
+                y2 = ones(size(x1)) .* halfamp .* flip;
+                [x_intersect, y_intersect] = intersections(x1,y1,x2,y2,true);
+                
+                if length(x_intersect) < 2
+                    ok = false;
+                elseif all(x_intersect <=0) || all(x_intersect >=0)
+                    ok = false;
+                else
+                    indx(1) = find(x_intersect <0, 1, 'last');
+                    indx(2) = find(x_intersect >0, 1, 'first');
+                    halfwidth.val = diff(x_intersect(indx));
+                    halfwidth.x = x_intersect(indx);
+                    halfwidth.y = y_intersect(indx);
+                    %scatter(halfwidth.x, halfwidth.y, 'xk');
+                    
+                    % Find throughs
+                    [Yneg,Xneg_temp] = findpeaks(-waveformavg.avg.*flip,waveformavg.time);
+                    
+                    if length(Xneg_temp) >= 2
+                        % Search first through before and after peak
+                        [Xneg(1),x_idx]  = max(Xneg_temp(Xneg_temp-amplitude.x < 0));
+                        [Xneg(2), ~] = min(Xneg_temp(Xneg_temp-amplitude.x > 0));
+                        Yneg = Yneg([x_idx, x_idx+1]);
+                        
+                        peaktrough.val = abs(amplitude.x-Xneg(1));
+                        peaktrough.x = [Xneg(1)  amplitude.x];
+                        peaktrough.y = [-Yneg(1)*flip amplitude.y];
+                        troughpeak.val = abs(amplitude.x-Xneg(2));
+                        troughpeak.x = [amplitude.x Xneg(2)];
+                        troughpeak.y = [amplitude.y -Yneg(2)*flip];
+                        %scatter(peaktrough.x, peaktrough.y, 'xk');
+                        %scatter(troughpeak.x, troughpeak.y, 'xk');
+                    end
+                end
+            else
+                ok = false;
+            end %isempty
+            
+            %store for output
+            if ok
+                stats{ipart}.(markername).waveformavg{icluster}    = waveformavg;
+                stats{ipart}.(markername).amplitude.val(icluster)  = amplitude.val;
+                stats{ipart}.(markername).amplitude.x(icluster)    = amplitude.x;
+                stats{ipart}.(markername).amplitude.y(icluster)    = amplitude.y;
+                stats{ipart}.(markername).halfwidth.val(icluster)  = halfwidth.val;
+                stats{ipart}.(markername).halfwidth.x(icluster,:)  = halfwidth.x;
+                stats{ipart}.(markername).halfwidth.y(icluster,:)  = halfwidth.y;
+                stats{ipart}.(markername).peaktrough.val(icluster) = peaktrough.val;
+                stats{ipart}.(markername).peaktrough.x(icluster,:) = peaktrough.x;
+                stats{ipart}.(markername).peaktrough.y(icluster,:) = peaktrough.y;
+                stats{ipart}.(markername).troughpeak.val(icluster) = troughpeak.val;
+                stats{ipart}.(markername).troughpeak.x(icluster,:) = troughpeak.x;
+                stats{ipart}.(markername).troughpeak.y(icluster,:) = troughpeak.y;
+            else
+                stats{ipart}.(markername).waveformavg{icluster}    = nan;
+                stats{ipart}.(markername).amplitude.val(icluster)  = nan;
+                stats{ipart}.(markername).amplitude.x(icluster)    = nan;
+                stats{ipart}.(markername).amplitude.y(icluster)    = nan;
+                stats{ipart}.(markername).halfwidth.val(icluster)  = nan;
+                stats{ipart}.(markername).halfwidth.x(icluster,:)  = nan;
+                stats{ipart}.(markername).halfwidth.y(icluster,:)  = nan;
+                stats{ipart}.(markername).peaktrough.val(icluster) = nan;
+                stats{ipart}.(markername).peaktrough.x(icluster,:) = nan;
+                stats{ipart}.(markername).peaktrough.y(icluster,:) = nan;
+                stats{ipart}.(markername).troughpeak.val(icluster) = nan;
+                stats{ipart}.(markername).troughpeak.x(icluster,:) = nan;
+                stats{ipart}.(markername).troughpeak.y(icluster,:) = nan;
+            end
+        end
+        ft_progress('close');
+    end
+end
+    
+save(fname_out, 'stats', '-v7.3');        
+

--- a/shared/spikeWaveformStats.m
+++ b/shared/spikeWaveformStats.m
@@ -40,9 +40,9 @@ else
 end
 
 % add external/intersections path if not already
-mfile_name          = mfilename('fullpath');
-pathstr             = fileparts(fileparts(mfile_name));
-pathCell            = regexp(path, pathsep, 'split');
+mfile_name = mfilename('fullpath');
+pathstr    = fileparts(fileparts(mfile_name));
+pathCell   = regexp(path, pathsep, 'split');
 if ispc  % Windows is not case-sensitive
     onPath = any(strcmpi(fullfile(pathstr, ['external', filesep, 'intersections']), pathCell));
 else
@@ -51,7 +51,6 @@ end
 if ~onPath
     addpath(fullfile(pathstr, ['external', filesep, 'intersections']));
 end
-
 
 for ipart = 1:size(SpikeWaveforms)
     for markername = string(fieldnames(SpikeWaveforms{ipart}))'
@@ -67,8 +66,8 @@ for ipart = 1:size(SpikeWaveforms)
                 evalc('waveformavg = ft_timelockanalysis([], SpikeWaveforms{ipart}.(markername){icluster});');%remove text output
                 
                 %interpolate the averaged waveform to have more precise values
-                time_temp = linspace(waveformavg.time(1),waveformavg.time(end),1000);
-                avg_temp  = pchip(waveformavg.time,waveformavg.avg,time_temp);
+                time_temp        = linspace(waveformavg.time(1),waveformavg.time(end),1000);
+                avg_temp         = pchip(waveformavg.time,waveformavg.avg,time_temp);
                 waveformavg.time = time_temp;
                 waveformavg.avg  = avg_temp;
                 %scatter(waveformavg.time, waveformavg.avg, '.');
@@ -86,22 +85,20 @@ for ipart = 1:size(SpikeWaveforms)
                 
                 %halfwidth
                 halfamp     = bl+(peak-bl)/2;
-                x1 = waveformavg.time;
+                x  = waveformavg.time;
                 y1 = waveformavg.avg;
-                x2 = x1;
                 y2 = ones(size(x1)) .* halfamp .* flip;
-                [x_intersect, y_intersect] = intersections(x1,y1,x2,y2,true);
+                [x_intersect, y_intersect] = intersections(x,y1,x,y2,true);
                 
                 if length(x_intersect) < 2
                     ok = false;
                 elseif all(x_intersect <=0) || all(x_intersect >=0)
                     ok = false;
                 else
-                    indx(1) = find(x_intersect <0, 1, 'last');
-                    indx(2) = find(x_intersect >0, 1, 'first');
-                    halfwidth.val = diff(x_intersect(indx));
-                    halfwidth.x = x_intersect(indx);
-                    halfwidth.y = y_intersect(indx);
+                    idx = find(x_intersect <0, 1, 'last');
+                    halfwidth.val = diff(x_intersect([idx, idx+1]));
+                    halfwidth.x   = x_intersect([idx, idx+1]);
+                    halfwidth.y   = y_intersect([idx, idx+1]);
                     %scatter(halfwidth.x, halfwidth.y, 'xk');
                     
                     % Find throughs
@@ -109,16 +106,16 @@ for ipart = 1:size(SpikeWaveforms)
                     
                     if length(Xneg_temp) >= 2
                         % Search first through before and after peak
-                        [Xneg(1),x_idx]  = max(Xneg_temp(Xneg_temp-amplitude.x < 0));
-                        [Xneg(2), ~] = min(Xneg_temp(Xneg_temp-amplitude.x > 0));
-                        Yneg = Yneg([x_idx, x_idx+1]);
+                        [Xneg(1),x_idx] = max(Xneg_temp(Xneg_temp-amplitude.x < 0));
+                        [Xneg(2), ~]    = min(Xneg_temp(Xneg_temp-amplitude.x > 0));
+                        Yneg            = Yneg([x_idx, x_idx+1]);
                         
-                        peaktrough.val = abs(amplitude.x-Xneg(1));
-                        peaktrough.x = [Xneg(1)  amplitude.x];
-                        peaktrough.y = [-Yneg(1)*flip amplitude.y];
-                        troughpeak.val = abs(amplitude.x-Xneg(2));
-                        troughpeak.x = [amplitude.x Xneg(2)];
-                        troughpeak.y = [amplitude.y -Yneg(2)*flip];
+                        peaktrough.val  = abs(amplitude.x-Xneg(1));
+                        peaktrough.x    = [Xneg(1)  amplitude.x];
+                        peaktrough.y    = [-Yneg(1)*flip amplitude.y];
+                        troughpeak.val  = abs(amplitude.x-Xneg(2));
+                        troughpeak.x    = [amplitude.x Xneg(2)];
+                        troughpeak.y    = [amplitude.y -Yneg(2)*flip];
                         %scatter(peaktrough.x, peaktrough.y, 'xk');
                         %scatter(troughpeak.x, troughpeak.y, 'xk');
                     end
@@ -128,7 +125,7 @@ for ipart = 1:size(SpikeWaveforms)
             end %isempty
             
             %store for output
-            stats{ipart}.(markername).label{icluster}          = SpikeWaveforms{ipart}.(markername){icluster}.label{1};
+            stats{ipart}.(markername).label{icluster}              = SpikeWaveforms{ipart}.(markername){icluster}.label{1};
             if ok
                 stats{ipart}.(markername).waveformavg{icluster}    = waveformavg;
                 stats{ipart}.(markername).amplitude.val(icluster)  = amplitude.val;
@@ -163,5 +160,4 @@ for ipart = 1:size(SpikeWaveforms)
     end
 end
     
-save(fname_out, 'stats', '-v7.3');        
-
+save(fname_out, 'stats', '-v7.3');


### PR DESCRIPTION
Hi Stephen,
Here is a PR with some modifs I made for my needs. Let me know if it is fine.
Cheers,
Paul

**readLFP** : I added artefact detection

**SpikeRaw** : 'phydir' is not defined at the moment of the error, I replaced it by the name of the dir.

**readSpikeTrials_MuseMarkers** :
- I have data with seizures (DTX rats) and data without (control rats). Rather than filtering them in the config, I would prefer than the script automatically does it, ie if there are no markers to timelock, output an empty structure. Then I can use the same script to analyse control and dtx rats. For that, I initialized an empty `SpikeTrials{ipart}.(markername) `before searching for markers.
- Also, for artefacts, I want afterwards to keep trials if artefact length is too small. For that, I sum all artefact lengths occuring in the trial, and add this value to trialinfo. So then the method I suggested, based on finding nearest indexes, does not seem fine for this purpose, so I left the other one, which is much longer but still 'just' several minutes. 

**readSpikeTrials_windowed** : add artefact length to trialinfo

**spikeTrialDensity** :
- Initialize empty stats to output if there is no timelocked data.
- I like to have a non-smoothed psth, I added it in this function, let me know if you think it is not the place for that.
- I want to compute spike density of different size, for that I need different parameters, so I added `.(markername)` at `cfg.spike.resamplefs` and `cfg.spike.sdftimwin`
- Is there a reason why you need to re-specify the latency with cfg.spike.latency and not use the whole trials ? For me it is problematic because in readSpikeTrials_MuseMarkers, the trial is defined by `start = marker1 + cfg.spike.toi(1)` and `end = marker2 + cfg.spike.toi(2)`. If marker1 and marker2 are different, then cfg.spike.toi do not define by itself the period of interest, but relatively to marker1 and marker2. So, when using it to define latency with ft_spikedensity, it takes a wrong latency. I removed the cfgtemp.latency parameter to avoid this mistake on my data.

**spikeTrialStats** : I added computation of RPV

**spikeWaveformStats** : I made this new function trying to be the most consistent as possible compared to what you did with the other spike functions. I compute values in interpolated average waveform and store also x and y positions if need to plot it later.