### PR TITLE
Test force

### DIFF
--- a/shared/spikeTrialDensity.m
+++ b/shared/spikeTrialDensity.m
@@ -1,11 +1,11 @@
-function stats = spikeTrialDensity(cfg, SpikeTrials, force)
+function [stats] = spikeTrialDensity(cfg, SpikeTrials, force)
 
 % SPIKERATESTATSEVENTS calculates spike statistics
 %
 % use as
-%   stats = spikeTrialDensity(cfg, SpikeTrials, force)
+%   [stats] = spikeTrialDensity(cfg, SpikeTrials, force)
 % or, if need to only load precomputed data :
-%   stats = spikeTrialDensity(cfg)
+%   [stats] = spikeTrialDensity(cfg)
 % 
 % This file is part of EpiCode, see
 % http://www.github.com/stephenwhitmarsh/EpiCode for documentation and details.

--- a/shared/spikeTrialDensity.m
+++ b/shared/spikeTrialDensity.m
@@ -1,10 +1,12 @@
-function [stats] = spikeTrialDensity(cfg, SpikeTrials, force)
+function stats = spikeTrialDensity(cfg, SpikeTrials, force)
 
 % SPIKERATESTATSEVENTS calculates spike statistics
 %
 % use as
-%   [stats] = spikeTrialDensity(cfg, SpikeTrials, force)
-
+%   stats = spikeTrialDensity(cfg, SpikeTrials, force)
+% or, if need to only load precomputed data :
+%   stats = spikeTrialDensity(cfg)
+% 
 % This file is part of EpiCode, see
 % http://www.github.com/stephenwhitmarsh/EpiCode for documentation and details.
 %
@@ -21,19 +23,31 @@ function [stats] = spikeTrialDensity(cfg, SpikeTrials, force)
 %   You should have received a copy of the GNU General Public License
 %   along with EpiCode. If not, see <http://www.gnu.org/licenses/>.
 
-cfg.spike.part_list     = ft_getopt(cfg.spike, 'part_list', 'all');
+fname = fullfile(cfg.datasavedir, [cfg.prefix, 'spikeTrialDensity.mat']);
 
-if strcmp(cfg.spike.part_list, 'all')
-    cfg.spike.part_list = 1:size(cfg.directorylist, 2);
+if nargin == 1
+    if exist(fname, 'file')
+        fprintf('Reading %s\n', fname);
+        load(fname, 'stats');
+        return;
+    else
+        warning('No precomputed data is found, not enough input arguments to compute data');
+        stats = {};
+        return
+    end
 end
 
-fname = fullfile(cfg.datasavedir, [cfg.prefix, 'spikeTrialDensity.mat']);
 if exist(fname, 'file') && force == false
     fprintf('Loading %s\n', fname);
     load(fname, 'stats');
     return
 end
 
+cfg.spike.part_list     = ft_getopt(cfg.spike, 'part_list', 'all');
+
+if strcmp(cfg.spike.part_list, 'all')
+    cfg.spike.part_list = 1:size(cfg.directorylist, 2);
+end
 stats = {};
 
 for ipart = cfg.spike.part_list

--- a/trash/test_force.m
+++ b/trash/test_force.m
@@ -1,0 +1,20 @@
+%test force
+addpath (genpath('\\lexport\iss01.charpier\analyses\lgi1\Git-Paul\EpiCode\development'));
+addpath \\lexport\iss01.charpier\analyses\lgi1\Git-Paul\fieldtrip;
+ft_defaults
+addpath (genpath('\\lexport\iss01.charpier\analyses\lgi1\Git-Paul\EpiCode\projects\dtx'));
+addpath (genpath('\\lexport\iss01.charpier\analyses\lgi1\Git-Paul\EpiCode\shared'));
+addpath (genpath('\\lexport\iss01.charpier\analyses\lgi1\Git-Paul\NeuralynxMatlabImportExport_v6.0.0'));
+addpath (genpath('\\lexport\iss01.charpier\analyses\lgi1\Git-Paul\EpiCode\external'));
+
+%load precomputed data for the test :
+config = dtx_spikes_setparams;
+SpikeTrials_timelocked  = readSpikeTrials_MuseMarkers(config{1}, [], [], false);
+SpikeTrials_timelocked  = removeArtefactedTrials(config{1}, SpikeTrials_timelocked);
+
+% do the test :
+stats1 = spikeTrialDensity(config{1});
+stats2 = spikeTrialDensity(config{1}, SpikeTrials_timelocked, false);
+stats3 = spikeTrialDensity(config{1}, SpikeTrials_timelocked, true);
+
+%for me, stats1, stats2 and stats3 are identical


### PR DESCRIPTION
Here is an example of function (I took SpikeTrialsDensity), modified with a suggestion of improvment to load precomputed data :
- If there is only 1 input argument (verified by 'if nargin == 1'), return precomputed data, if it exists, else return empty. 
- I attached a test script, in 'trash', with the 3 ways of using the function, the 3 are tested for my data and work.
- I also suggested a modification in the header, to document this new way of using the function.

Note that I already used 'nargin' in writeSpykingCircusDeadfiles, so the last output (suffix) can be here or not. Line 27, 'if nargin < 4' verifies if the last output is here or not, and if not, it sets a default value.

I think it is good as it does not break the previous versions, and, no need to add empty arguments before reaching 'force'. Let me know if it suits you :) 
Cheers,
Paul