### PR TITLE
fix bug in alignMuseMarkersXcorr.m and add average referencing

### DIFF
--- a/shared/readLFP.m
+++ b/shared/readLFP.m
@@ -214,7 +214,7 @@ for markername = string(cfg.LFP.name)
                 else
                     cfgtemp             = [];
                     cfgtemp.dataset     = fname;
-                    cfgtemp.channel     = cfg.labels.macro';
+                    cfgtemp.channel     = cfg.LFP.channel;
                     dat                 = ft_preprocessing(cfgtemp);
                 end
                 


### PR DESCRIPTION
Hi Stephen,
I looked to the alignMuseMarkersXcorr.m function for some patients IED, and it has very good results ! However I wanted to share the following points :

- I fixed one issue, which could also impact your analysis. The plot generated by the function were very nice with a convincing alignment. But then, when I tried to reproduce such plot with my data read with the 'aligned' MuseStruct, it was not that well. I then found that there was a mistake in line 293 when creating the aligned MuseStruct : you should use either nshift_clean(i) or nshift(ievent), but not nshift(i). With this error, all trials occurring after a 'rejected' trial did not have the good timeshift.
- I added the possibility to do average referecing. I first load both cfg.align.channel and cfg.align.refchannel. Then, once the referencing is done, I keep only the channels of cfg.align.channel with ft_selectdata.


- Also, in readLFP, I removed an old nomenclature : cfg.labels.macro replaced by cfg.LFP.channel.

Cheers
Paul

