### PR TITLE
fix issue when removing artefacted trials in alignMuseMarkersXcorr.m

### DIFF
--- a/shared/alignMuseMarkersXcorr.m
+++ b/shared/alignMuseMarkersXcorr.m
@@ -21,7 +21,9 @@ function [MuseStruct] = alignMuseMarkersXcorr(cfg, MuseStruct, force)
 % config{1}.align.latency.PSW = e.g.: [-0.1 2]; % time period to use for alignment
 % config{1}.align.latency.FA  = e.g.: [-0.1 0.4];
 % config{1}.align.latency.ES  = e.g.: [-0.1 0.4];
-
+% config{1}.align.reject      = e.g.: 'BAD_cnt'; %fieldname in trialinfo used
+%                               to reject trials, see readLFP and cfg.LFP.overlap.
+% 
 % This file is part of EpiCode, see
 % http://www.github.com/stephenwhitmarsh/EpiCode for documentation and details.
 %
@@ -287,7 +289,7 @@ for ipart = 1 : size(cfg.directorylist,2)
         end
         
         %% correct MuseStruct
-        i = 1;
+        i = 0;
         for idir = 1 : length(MuseStruct{ipart})
             if ~isfield(MuseStruct{ipart}{idir},'markers')
                 continue
@@ -305,8 +307,9 @@ for ipart = 1 : size(cfg.directorylist,2)
             
             for ievent = 1 : size(MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).synctime, 2)
                 if any(dat.trialinfo.trialnr == ievent & dat.trialinfo.idir == idir)
-                    timeshift = nshift(ievent) / dat.fsample;
-                    fprintf('Timeshifting %s #%d in part %d by %d samples (%0.3f seconds) \n', markername, ievent, ipart, nshift(ievent),timeshift);
+                    i = i + 1;
+                    timeshift = nshift_clean(i) / dat.fsample;
+                    fprintf('Timeshifting %s #%d in part %d by %d samples (%0.3f seconds) \n', markername, ievent, ipart, nshift_clean(i),timeshift);
                     MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).timeshift(ievent) = timeshift;
                     MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).synctime(ievent)  = MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).synctime(ievent) - timeshift;
                     MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).clock(ievent)     = MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).clock(ievent) - seconds(timeshift); % direction should be tripple-checked

--- a/shared/readLFP.m
+++ b/shared/readLFP.m
@@ -58,6 +58,8 @@ cfg.LFP.rerefmethod = ft_getopt(cfg.LFP, 'rerefmethod', []);
 cfg.LFP.refchannel  = ft_getopt(cfg.LFP, 'refchannel', []);
 cfg.LFP.postfix     = ft_getopt(cfg.LFP, 'postfix', []);
 cfg.LFP.overlap     = ft_getopt(cfg.LFP, 'overlap', []);
+cfg.spike           = ft_getopt(cfg, 'spike', []);
+cfg.spike.overlap   = ft_getopt(cfg.spike, 'overlap', []);
 
 % add markers to always look for overlap for
 cfg.LFP.overlap                 = unique([cfg.spike.overlap, "BAD", "PHASE_1", "PHASE_2", "PHASE_3", "REM", "AWAKE", "PRESLEEP", "POSTSLEEP"], 'stable');
@@ -329,8 +331,8 @@ for markername = string(cfg.LFP.name)
                     Endtime(ievent)         = MuseStruct{ipart}{idir}.markers.(cfg.muse.endmarker.(markername)).clock(ievent)   + seconds(cfg.epoch.toi.(markername)(2));
                     
                     % will be used to find overlap between events
-                    trlstart                = MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).synctime(ievent) + cfg.epoch.toi.(markername)(1) * dat.fsample;
-                    trlend                  = MuseStruct{ipart}{idir}.markers.(cfg.muse.endmarker.(markername)).synctime(ievent) + cfg.epoch.toi.(markername)(2) * dat.fsample;       
+                    trlstart                = MuseStruct{ipart}{idir}.markers.(cfg.muse.startmarker.(markername)).synctime(ievent) + cfg.epoch.toi.(markername)(1);
+                    trlend                  = MuseStruct{ipart}{idir}.markers.(cfg.muse.endmarker.(markername)).synctime(ievent) + cfg.epoch.toi.(markername)(2);       
 
                     % find overlap
                     for iother = 1 : size(cfg.LFP.overlap, 2)


### PR DESCRIPTION
Hi Stephen,

Here are 2 little modifications : 

- in readLFP : replace cfg.spike by cfg.LFP (we discussed it yesterday)

- in alignMuseMarkersXcorr : when, at the onset of the script, I remove trials according to overlaps with Muse "BAD", I have then less trials than Muse markers. So, the indexing at the end, based on Muse Markers, does not work anymore. At one point 'ievent' becomes higher than the size of 'nshift', because of the trials removed with cfg.align.reject. Therefore, I put back the solution with the "i" index increasing 1 by 1, applied on "clean" data. I checked it by launching the script without removing artefacted trials, and I get exactly the same results with both methods. 

Cheers,
Paul